### PR TITLE
Changed http method override setting

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -2,7 +2,7 @@
 framework:
   secret: '%env(APP_SECRET)%'
   #csrf_protection: true
-  #    http_method_override: true
+  http_method_override: true
 
   # the IP address (or range) of your proxy
   trusted_proxies : '127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16'


### PR DESCRIPTION
This should be set to true so html forms can send other methods besides GET and POST